### PR TITLE
Enable usage of multiple '{{here}}' placeholder in a custom template

### DIFF
--- a/src/completionItemBuilder.ts
+++ b/src/completionItemBuilder.ts
@@ -29,9 +29,9 @@ export class CompletionItemBuilder {
     if (useSnippets) {
       const escapedCode = codeBeforeTheDot.replace('$', '\\$')
 
-      this.item.insertText = new vsc.SnippetString(replacement.replace('{{expr}}', escapedCode))
+      this.item.insertText = new vsc.SnippetString(replacement.replace(new RegExp('{{expr}}', 'g'), escapedCode))
     } else {
-      this.item.insertText = replacement.replace('{{expr}}', codeBeforeTheDot)
+      this.item.insertText = replacement.replace(new RegExp('{{expr}}', 'g'), codeBeforeTheDot)
     }
 
     this.item.additionalTextEdits = [

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -87,6 +87,33 @@ describe('Simple template tests', () => {
     it('function-call', testTemplate('call()', 'custom', '!call()'))
     it('function-call 2', testTemplate('test.call()', 'custom', '!test.call()'))
   })
+
+  describe('custom template with multiple expr tests', () => {
+    const config = vsc.workspace.getConfiguration('postfix')
+
+    before(done => {
+      config.update('customTemplates', [{
+        'name': 'double',
+        'body': '{{expr}} + {{expr}}',
+        'description': 'double expr',
+        'when': [
+          'identifier', 'unary-expression', 'binary-expression', 'expression', 'function-call'
+        ]
+      }], true).then(() => done(), err => done(err))
+    })
+
+    after(done => {
+      config.update('customTemplates', undefined, true).then(done, err => done(err))
+    })
+
+    it('identifier', testTemplate('expr', 'double', 'expr + expr'))
+    it('expression', testTemplate('expr.test', 'double', 'expr.test + expr.test'))
+    it('expression 2', testTemplate('expr[index]', 'double', 'expr[index] + expr[index]'))
+    it('binary-expression', testTemplate('x > 100', 'double', 'x > 100 + x > 100'))
+    it('unary-expression', testTemplate('!x', 'double', '!x + !x'))
+    it('function-call', testTemplate('call()', 'double', 'call() + call()'))
+    it('function-call 2', testTemplate('test.call()', 'double', 'test.call() + test.call()'))
+  })
 })
 
 function testTemplate (initialText: string, template: string, expectedResult: string, trimWhitespaces?: boolean) {


### PR DESCRIPTION
as commit says :)

Here is the custom template I want to be able to support:
```json
{
            "name": "ll",
            "description": "detailed log",
            "body": "console.log('{{expr}}', {{expr}});$0",
            "when": [
                "expression"
            ]
        }
```

I added test for the fixtures + Implementation is rather simple, feeding a global regexp to replace