### PR TITLE
Improve extension size and performance

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ node_modules
 /.vscode-test
 /test/index.ts
 /tasks.js
+build.js

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,4 @@ coverage/**
 tasks.js
 coverconfig.json
 .github/**
+node_modules

--- a/build.js
+++ b/build.js
@@ -1,0 +1,25 @@
+const production = process.argv[2] === "--production";
+const watch = process.argv[2] === "--watch";
+
+require("esbuild")
+  .build({
+    entryPoints: ["./src/extension.ts"],
+    bundle: true,
+    outdir: "out",
+    external: ["vscode"],
+    format: "cjs",
+    sourcemap: !production,
+    minify: production,
+    platform: "node",
+    target: ["node12"],
+    watch: watch && {
+      onRebuild(error) {
+        if (error) console.error("watch build failed:", error);
+        else console.log("watch build succeeded");
+      },
+    },
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/build.js
+++ b/build.js
@@ -11,7 +11,6 @@ require("esbuild")
     sourcemap: !production,
     minify: production,
     platform: "node",
-    target: ["node12"],
     watch: watch && {
       onRebuild(error) {
         if (error) console.error("watch build failed:", error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-postfix-ts",
-	"version": "1.9.2",
+	"version": "1.10.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -757,6 +757,150 @@
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
+		},
+		"esbuild": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+			"integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+			"dev": true,
+			"requires": {
+				"esbuild-android-arm64": "0.13.15",
+				"esbuild-darwin-64": "0.13.15",
+				"esbuild-darwin-arm64": "0.13.15",
+				"esbuild-freebsd-64": "0.13.15",
+				"esbuild-freebsd-arm64": "0.13.15",
+				"esbuild-linux-32": "0.13.15",
+				"esbuild-linux-64": "0.13.15",
+				"esbuild-linux-arm": "0.13.15",
+				"esbuild-linux-arm64": "0.13.15",
+				"esbuild-linux-mips64le": "0.13.15",
+				"esbuild-linux-ppc64le": "0.13.15",
+				"esbuild-netbsd-64": "0.13.15",
+				"esbuild-openbsd-64": "0.13.15",
+				"esbuild-sunos-64": "0.13.15",
+				"esbuild-windows-32": "0.13.15",
+				"esbuild-windows-64": "0.13.15",
+				"esbuild-windows-arm64": "0.13.15"
+			}
+		},
+		"esbuild-android-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+			"integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-darwin-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+			"integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-darwin-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+			"integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-freebsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+			"integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-freebsd-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+			"integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+			"integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+			"integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-arm": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+			"integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+			"integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-mips64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+			"integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-ppc64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+			"integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-netbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+			"integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-openbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+			"integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-sunos-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+			"integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-windows-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+			"integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-windows-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+			"integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-windows-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+			"integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+			"dev": true,
+			"optional": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,127 +1,131 @@
 {
-	"name": "vscode-postfix-ts",
-	"displayName": "TS/JS postfix completion",
-	"description": "Postfix templates for TypeScript/Javascript",
-	"version": "1.9.3",
-	"license": "MIT",
-	"publisher": "ipatalas",
-	"engines": {
-		"vscode": "^1.20.0"
-	},
-	"icon": "images/logo.png",
-	"categories": [
-		"Snippets",
-		"Other"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/ipatalas/vscode-postfix-ts"
-	},
-	"bugs": {
-		"url": "https://github.com/ipatalas/vscode-postfix-ts/issues"
-	},
-	"activationEvents": [
-		"*"
-	],
-	"main": "./out/src/extension",
-	"contributes": {
-		"configuration": {
-			"title": "Postfix completion",
-			"properties": {
-				"postfix.languages": {
-					"type": "array",
-					"description": "A list of languages in which the completion will be available",
-					"default": [
-						"javascript",
-						"typescript",
-						"javascriptreact",
-						"typescriptreact"
-					]
-				},
-				"postfix.undefinedMode": {
-					"type": "string",
-					"markdownDescription": "Determines how the `.undefined` and `.notundefined` templates work",
-					"default": "Equal",
-					"enum": [
-						"Equal",
-						"Typeof"
-					],
-					"enumDescriptions": [
-						"if (expr === undefined)",
-						"if (typeof expr === \"undefined\")"
-					]
-				},
-				"postfix.customTemplates": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"required": [
-							"name",
-							"body"
-						],
-						"properties": {
-							"name": {
-								"type": "string",
-								"description": "Name of the template. It will be used in auto-complete suggestions"
-							},
-							"description": {
-								"type": "string",
-								"description": "Description of the template. It will be used in auto-complete suggestions"
-							},
-							"body": {
-								"type": "string",
-								"description": "Body of the template. {{expr}} will be replaced with the expression before the cursor"
-							},
-							"when": {
-								"type": "array",
-								"description": "Context in which the template should be suggested",
-								"items": {
-									"type": "string",
-									"enum": [
-										"identifier",
-										"expression",
-										"binary-expression",
-										"unary-expression",
-										"function-call",
-										"new-expression",
-										"type"
-									]
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "tsc -p ./",
-		"compile": "tsc -watch -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install",
-		"test": "cross-env NODE_ENV=test node ./node_modules/vscode/bin/test",
-		"pretest": "node ./tasks.js pretest && tsc -p ./",
-		"prerun": "node ./tasks.js prerun",
-		"build": "npm run prerun && npm run compile",
+  "name": "vscode-postfix-ts",
+  "displayName": "TS/JS postfix completion",
+  "description": "Postfix templates for TypeScript/Javascript",
+  "version": "1.10.0",
+  "license": "MIT",
+  "publisher": "ipatalas",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "icon": "images/logo.png",
+  "categories": [
+    "Snippets",
+    "Other"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ipatalas/vscode-postfix-ts"
+  },
+  "bugs": {
+    "url": "https://github.com/ipatalas/vscode-postfix-ts/issues"
+  },
+  "activationEvents": [
+    "onLanguage:javascript",
+    "onLanguage:typescript",
+    "onLanguage:javascriptreact",
+    "onLanguage:typescriptreact"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "configuration": {
+      "title": "Postfix completion",
+      "properties": {
+        "postfix.languages": {
+          "type": "array",
+          "description": "A list of languages in which the completion will be available",
+          "default": [
+            "javascript",
+            "typescript",
+            "javascriptreact",
+            "typescriptreact"
+          ]
+        },
+        "postfix.undefinedMode": {
+          "type": "string",
+          "markdownDescription": "Determines how the `.undefined` and `.notundefined` templates work",
+          "default": "Equal",
+          "enum": [
+            "Equal",
+            "Typeof"
+          ],
+          "enumDescriptions": [
+            "if (expr === undefined)",
+            "if (typeof expr === \"undefined\")"
+          ]
+        },
+        "postfix.customTemplates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "body"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the template. It will be used in auto-complete suggestions"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the template. It will be used in auto-complete suggestions"
+              },
+              "body": {
+                "type": "string",
+                "description": "Body of the template. {{expr}} will be replaced with the expression before the cursor"
+              },
+              "when": {
+                "type": "array",
+                "description": "Context in which the template should be suggested",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "identifier",
+                    "expression",
+                    "binary-expression",
+                    "unary-expression",
+                    "function-call",
+                    "new-expression",
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "node ./build.js --production",
+    "compile": "node ./build.js",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "cross-env NODE_ENV=test node ./node_modules/vscode/bin/test",
+    "pretest": "node ./tasks.js pretest && node ./build.js",
+    "prerun": "node ./tasks.js prerun",
+    "build": "npm run prerun && npm run compile",
     "deploy": "vsce publish"
-	},
-	"devDependencies": {
-		"@types/lodash": "^4.14.168",
-		"@types/mocha": "^5.2.7",
-		"@types/node": "^10.14.17",
-		"@typescript-eslint/eslint-plugin": "^4.15.2",
-		"@typescript-eslint/parser": "^4.15.2",
-		"cross-env": "^7.0.3",
-		"decache": "^4.5.1",
-		"eslint": "^7.21.0",
-		"istanbul": "^0.4.5",
-		"mocha": "^5.2.0",
-		"remap-istanbul": "^0.13.0",
-		"vsce": "^1.85.1",
-		"vscode": "^1.1.37"
-	},
-	"dependencies": {
-		"glob": "^7.1.6",
-		"lodash": "^4.17.21",
-		"typescript": "^4.2.2"
-	}
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.168",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^10.14.17",
+    "@typescript-eslint/eslint-plugin": "^4.15.2",
+    "@typescript-eslint/parser": "^4.15.2",
+    "cross-env": "^7.0.3",
+    "decache": "^4.5.1",
+    "esbuild": "^0.13.15",
+    "eslint": "^7.21.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.2.0",
+    "remap-istanbul": "^0.13.0",
+    "vsce": "^1.85.1",
+    "vscode": "^1.1.37"
+  },
+  "dependencies": {
+    "glob": "^7.1.6",
+    "lodash": "^4.17.21",
+    "typescript": "^4.2.2"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,11 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "out",
-        "lib": [
-            "es6"
-        ],
-        "sourceMap": true,
-        "rootDir": "."
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": ["ES2020"],
+    "sourceMap": true,
+    "rootDir": "."
+  },
+  "exclude": ["node_modules", ".vscode-test", "build.js"]
 }


### PR DESCRIPTION
Before:
58.4 MB (61,314,657 bytes)
201ms startup time

After:
3.43 MB (3,607,464 bytes)
32ms startup time

- Adds a bundler to produce a smaller extension
- Only activates when within JS/TS file instead of on startup
- Bumps the JS version for less boilerplate code generated
- bumps version and minimum VSCode version


