### PR TITLE
Print render text instead of raw body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.21",
-				"typescript": "^4.6.4"
+				"typescript": "^4.6.4",
+				"vscode-snippet-parser": "^0.0.5"
 			},
 			"devDependencies": {
 				"@types/lodash": "^4.14.182",
@@ -4012,6 +4013,11 @@
 				"node": "*"
 			}
 		},
+		"node_modules/vscode-snippet-parser": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/vscode-snippet-parser/-/vscode-snippet-parser-0.0.5.tgz",
+			"integrity": "sha512-iJ5e7g5sCQJ5LRt5nGWtw10oHj44a+6flLAYbGlA2Jbu32UQtjJqGnaT/1TzMV8Tlig/fsrHf7NoMlAT8N+FmA=="
+		},
 		"node_modules/wide-align": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -4355,12 +4361,6 @@
 			"version": "1.62.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
 			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
-			"dev": true
-		},
-		"@types/vscode": {
-			"version": "1.63.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
-			"integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -7200,6 +7200,11 @@
 					}
 				}
 			}
+		},
+		"vscode-snippet-parser": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/vscode-snippet-parser/-/vscode-snippet-parser-0.0.5.tgz",
+			"integrity": "sha512-iJ5e7g5sCQJ5LRt5nGWtw10oHj44a+6flLAYbGlA2Jbu32UQtjJqGnaT/1TzMV8Tlig/fsrHf7NoMlAT8N+FmA=="
 		},
 		"wide-align": {
 			"version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,18 @@
 						"if (typeof expr === \"undefined\")"
 					]
 				},
+				"postfix.snippetPreviewMode": {
+					"type": "string",
+					"enum": [
+						"raw",
+						"inserted"
+					],
+					"default": "raw",
+					"markdownEnumDescriptions": [
+						"Raw snippet as you defined in settings.json",
+						"The inserted text variant"
+					]
+				},
 				"postfix.customTemplates": {
 					"type": "array",
 					"items": {
@@ -134,6 +146,7 @@
 	},
 	"dependencies": {
 		"lodash": "^4.17.21",
-		"typescript": "^4.6.4"
+		"typescript": "^4.6.4",
+		"vscode-snippet-parser": "^0.0.5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 						"raw",
 						"inserted"
 					],
-					"default": "raw",
+					"default": "inserted",
 					"markdownEnumDescriptions": [
 						"Raw snippet as you defined in settings.json",
 						"The inserted text variant"

--- a/src/completionItemBuilder.ts
+++ b/src/completionItemBuilder.ts
@@ -1,6 +1,7 @@
 import * as vsc from 'vscode'
 import ts = require('typescript')
 import { adjustMultilineIndentation } from './utils/multiline-expressions'
+import { SnippetParser } from 'vscode-snippet-parser'
 
 const RegexExpression = '{{expr(?::(upper|lower|capitalize))?}}'
 
@@ -69,7 +70,12 @@ export class CompletionItemBuilder {
   }
 
   private addCodeBlockDescription = (replacement: string) => {
-    const addCodeBlock = (md: vsc.MarkdownString) => md.appendCodeblock(this.replaceExpression(replacement, this.code), 'ts')
+    const addCodeBlock = (md: vsc.MarkdownString) => {
+      const code = this.replaceExpression(replacement, this.code);
+      const snippetPreviewMode = vsc.workspace.getConfiguration('postfix', null)
+        .get<'raw' | 'inserted'>('snippetPreviewMode')
+      return md.appendCodeblock(snippetPreviewMode === 'inserted' ? new SnippetParser().text(code) : code, 'ts');
+    }
 
     if (!this.item.documentation) {
       const md = new vsc.MarkdownString();


### PR DESCRIPTION
I see you just started printing the body of the snippet. This PR improves this preview.

Now snippets preview look like this:
![image](https://user-images.githubusercontent.com/46503702/169698062-2c1b722d-bd27-4c1a-bd20-945118f8356e.png)

With this we align our behaviour with how builtin vscode snippet completions works.

I've been [using it](https://github.com/zardoy/vscode-better-snippets/blob/072c330b5d485b91f598d2927d6308a4a180ac06/src/extension.ts#L230) for a while and can say that it works pretty well (even though the package is outdated). The only thing that it can't handle properly is transform part in snippets e.g. `${1/(.*)/${1:/capitalize}/}]`.

Also note as we started printing the body this preview can be really big. As an example `await` with 10 lines of call expression. 
