### PR TITLE
feat: Infer variable names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
-				"const-name": "0.0.1",
+				"const-name": "0.1.0",
 				"lodash": "^4.17.21",
 				"typescript": "^4.6.4"
 			},
@@ -952,11 +952,11 @@
 			"dev": true
 		},
 		"node_modules/const-name": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/const-name/-/const-name-0.0.1.tgz",
-			"integrity": "sha512-0ruY8qiKAj5zU6p+Xlme66rNLP6k8fKG8hfLHAPotnJBYuXDr0knDSku7zWWjDHm209yKa5Ag2yAlyiX8euDMA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/const-name/-/const-name-0.1.0.tgz",
+			"integrity": "sha512-Uiy2UWrgiuU8fcZptMKIttvjuAAHGrHqLaa+WTDODCC1suMpFJyPYoWfT1mDHsnan7gDqRTn2JXG7G0N9uAVJw==",
 			"dependencies": {
-				"pluralize": "github:plurals/pluralize"
+				"pluralize": "github:plurals/pluralize#36f03cd2d573fa6d23e12e1529fa4627e2af74b4"
 			},
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -4945,11 +4945,11 @@
 			"dev": true
 		},
 		"const-name": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/const-name/-/const-name-0.0.1.tgz",
-			"integrity": "sha512-0ruY8qiKAj5zU6p+Xlme66rNLP6k8fKG8hfLHAPotnJBYuXDr0knDSku7zWWjDHm209yKa5Ag2yAlyiX8euDMA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/const-name/-/const-name-0.1.0.tgz",
+			"integrity": "sha512-Uiy2UWrgiuU8fcZptMKIttvjuAAHGrHqLaa+WTDODCC1suMpFJyPYoWfT1mDHsnan7gDqRTn2JXG7G0N9uAVJw==",
 			"requires": {
-				"pluralize": "github:plurals/pluralize"
+				"pluralize": "github:plurals/pluralize#36f03cd2d573fa6d23e12e1529fa4627e2af74b4"
 			}
 		},
 		"core-util-is": {
@@ -6620,7 +6620,7 @@
 		},
 		"pluralize": {
 			"version": "git+ssh://git@github.com/plurals/pluralize.git#36f03cd2d573fa6d23e12e1529fa4627e2af74b4",
-			"from": "pluralize@github:plurals/pluralize"
+			"from": "pluralize@github:plurals/pluralize#36f03cd2d573fa6d23e12e1529fa4627e2af74b4"
 		},
 		"prebuild-install": {
 			"version": "7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
+				"const-name": "0.0.1",
 				"lodash": "^4.17.21",
 				"typescript": "^4.6.4"
 			},
@@ -949,6 +950,17 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
+		},
+		"node_modules/const-name": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/const-name/-/const-name-0.0.1.tgz",
+			"integrity": "sha512-0ruY8qiKAj5zU6p+Xlme66rNLP6k8fKG8hfLHAPotnJBYuXDr0knDSku7zWWjDHm209yKa5Ag2yAlyiX8euDMA==",
+			"dependencies": {
+				"pluralize": "github:plurals/pluralize"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
@@ -3205,6 +3217,14 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "git+ssh://git@github.com/plurals/pluralize.git#36f03cd2d573fa6d23e12e1529fa4627e2af74b4",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
@@ -4357,12 +4377,6 @@
 			"integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
 			"dev": true
 		},
-		"@types/vscode": {
-			"version": "1.63.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
-			"integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
-			"dev": true
-		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.25.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz",
@@ -4929,6 +4943,14 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
+		},
+		"const-name": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/const-name/-/const-name-0.0.1.tgz",
+			"integrity": "sha512-0ruY8qiKAj5zU6p+Xlme66rNLP6k8fKG8hfLHAPotnJBYuXDr0knDSku7zWWjDHm209yKa5Ag2yAlyiX8euDMA==",
+			"requires": {
+				"pluralize": "github:plurals/pluralize"
+			}
 		},
 		"core-util-is": {
 			"version": "1.0.3",
@@ -6595,6 +6617,10 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
+		},
+		"pluralize": {
+			"version": "git+ssh://git@github.com/plurals/pluralize.git#36f03cd2d573fa6d23e12e1529fa4627e2af74b4",
+			"from": "pluralize@github:plurals/pluralize"
 		},
 		"prebuild-install": {
 			"version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
 						"append",
 						"override"
 					]
+				},
+				"postfix.deriveVariableName": {
+					"type": "boolean",
+					"markdownDescription": "Try to guess variable names for `var`, `let`, `const`, `forEach` and `forof` templates.",
+					"default": true
 				}
 			}
 		}
@@ -133,6 +138,7 @@
 		"vsce": "^2.8.0"
 	},
 	"dependencies": {
+		"const-name": "0.0.1",
 		"lodash": "^4.17.21",
 		"typescript": "^4.6.4"
 	}

--- a/package.json
+++ b/package.json
@@ -1,145 +1,145 @@
 {
-	"name": "vscode-postfix-ts",
-	"displayName": "TS/JS postfix completion",
-	"description": "Postfix templates for TypeScript/Javascript",
-	"version": "1.10.0",
-	"license": "MIT",
-	"publisher": "ipatalas",
-	"engines": {
-		"vscode": "^1.60.0"
-	},
-	"icon": "images/logo.png",
-	"categories": [
-		"Snippets",
-		"Other"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/ipatalas/vscode-postfix-ts"
-	},
-	"bugs": {
-		"url": "https://github.com/ipatalas/vscode-postfix-ts/issues"
-	},
-	"activationEvents": [
-		"onLanguage:javascript",
-		"onLanguage:typescript",
-		"onLanguage:javascriptreact",
-		"onLanguage:typescriptreact"
-	],
-	"main": "./out/extension",
-	"contributes": {
-		"configuration": {
-			"title": "Postfix completion",
-			"properties": {
-				"postfix.languages": {
-					"type": "array",
-					"description": "A list of languages in which the completion will be available",
-					"default": [
-						"javascript",
-						"typescript",
-						"javascriptreact",
-						"typescriptreact"
-					]
-				},
-				"postfix.undefinedMode": {
-					"type": "string",
-					"markdownDescription": "Determines how the `.undefined` and `.notundefined` templates work",
-					"default": "Equal",
-					"enum": [
-						"Equal",
-						"Typeof"
-					],
-					"enumDescriptions": [
-						"if (expr === undefined)",
-						"if (typeof expr === \"undefined\")"
-					]
-				},
-				"postfix.customTemplates": {
-					"type": "array",
-					"items": {
-						"type": "object",
-						"required": [
-							"name",
-							"body"
-						],
-						"properties": {
-							"name": {
-								"type": "string",
-								"description": "Name of the template. It will be used in auto-complete suggestions"
-							},
-							"description": {
-								"type": "string",
-								"description": "Description of the template. It will be used in auto-complete suggestions"
-							},
-							"body": {
-								"type": "string",
-								"description": "Body of the template. {{expr}} will be replaced with the expression before the cursor"
-							},
-							"when": {
-								"type": "array",
-								"description": "Context in which the template should be suggested",
-								"items": {
-									"type": "string",
-									"enum": [
-										"identifier",
-										"expression",
-										"binary-expression",
-										"unary-expression",
-										"function-call",
-										"new-expression",
-										"type"
-									]
-								}
-							}
-						}
-					}
-				},
-				"postfix.customTemplate.mergeMode": {
-					"type": "string",
-					"markdownDescription": "Determines how custom templates are shown if they share a name with built-in template:\n`append` - both built-in and custom template will be shown\n`override` - only custom template will be shown (it overrides built-in one)",
-					"default": "append",
-					"enum": [
-						"append",
-						"override"
-					]
-				},
-				"postfix.deriveVariableName": {
-					"type": "boolean",
-					"markdownDescription": "Try to guess variable names for `var`, `let`, `const`, `forEach` and `forof` templates.",
-					"default": true
-				}
-			}
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "node ./build.js --production",
-		"compile": "node ./build.js",
-		"test": "cross-env NODE_ENV=test node ./out/test/runTests.js",
-		"pretest": "node ./tasks.js pretest && tsc -p ./",
-		"prerun": "node ./tasks.js prerun",
-		"build": "npm run prerun && npm run compile",
-		"lint": "eslint .",
-		"deploy": "vsce publish"
-	},
-	"devDependencies": {
-		"@types/lodash": "^4.14.182",
-		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.60.0",
-		"@typescript-eslint/eslint-plugin": "^5.25.0",
-		"@typescript-eslint/parser": "^5.25.0",
-		"@vscode/test-electron": "^2.1.3",
-		"cross-env": "^7.0.3",
-		"esbuild": "^0.13.15",
-		"eslint": "^8.16.0",
-		"glob": "^8.0.3",
-		"mocha": "^10.0.0",
-		"source-map-support": "0.5.21",
-		"vsce": "^2.8.0"
-	},
-	"dependencies": {
-		"const-name": "0.1.0",
-		"lodash": "^4.17.21",
-		"typescript": "^4.6.4"
-	}
+  "name": "vscode-postfix-ts",
+  "displayName": "TS/JS postfix completion",
+  "description": "Postfix templates for TypeScript/Javascript",
+  "version": "1.10.0",
+  "license": "MIT",
+  "publisher": "ipatalas",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "icon": "images/logo.png",
+  "categories": [
+    "Snippets",
+    "Other"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ipatalas/vscode-postfix-ts"
+  },
+  "bugs": {
+    "url": "https://github.com/ipatalas/vscode-postfix-ts/issues"
+  },
+  "activationEvents": [
+    "onLanguage:javascript",
+    "onLanguage:typescript",
+    "onLanguage:javascriptreact",
+    "onLanguage:typescriptreact"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "configuration": {
+      "title": "Postfix completion",
+      "properties": {
+        "postfix.languages": {
+          "type": "array",
+          "description": "A list of languages in which the completion will be available",
+          "default": [
+            "javascript",
+            "typescript",
+            "javascriptreact",
+            "typescriptreact"
+          ]
+        },
+        "postfix.undefinedMode": {
+          "type": "string",
+          "markdownDescription": "Determines how the `.undefined` and `.notundefined` templates work",
+          "default": "Equal",
+          "enum": [
+            "Equal",
+            "Typeof"
+          ],
+          "enumDescriptions": [
+            "if (expr === undefined)",
+            "if (typeof expr === \"undefined\")"
+          ]
+        },
+        "postfix.customTemplates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "body"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the template. It will be used in auto-complete suggestions"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the template. It will be used in auto-complete suggestions"
+              },
+              "body": {
+                "type": "string",
+                "description": "Body of the template. {{expr}} will be replaced with the expression before the cursor"
+              },
+              "when": {
+                "type": "array",
+                "description": "Context in which the template should be suggested",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "identifier",
+                    "expression",
+                    "binary-expression",
+                    "unary-expression",
+                    "function-call",
+                    "new-expression",
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "postfix.customTemplate.mergeMode": {
+          "type": "string",
+          "markdownDescription": "Determines how custom templates are shown if they share a name with built-in template:\n`append` - both built-in and custom template will be shown\n`override` - only custom template will be shown (it overrides built-in one)",
+          "default": "append",
+          "enum": [
+            "append",
+            "override"
+          ]
+        },
+        "postfix.inferVariableName": {
+          "type": "boolean",
+          "markdownDescription": "Try to guess variable names for `var`, `let`, `const`, `forEach` and `forof` templates.",
+          "default": true
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "node ./build.js --production",
+    "compile": "node ./build.js",
+    "test": "cross-env NODE_ENV=test node ./out/test/runTests.js",
+    "pretest": "node ./tasks.js pretest && tsc -p ./",
+    "prerun": "node ./tasks.js prerun",
+    "build": "npm run prerun && npm run compile",
+    "lint": "eslint .",
+    "deploy": "vsce publish"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.182",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^16.11.7",
+    "@types/vscode": "^1.60.0",
+    "@typescript-eslint/eslint-plugin": "^5.25.0",
+    "@typescript-eslint/parser": "^5.25.0",
+    "@vscode/test-electron": "^2.1.3",
+    "cross-env": "^7.0.3",
+    "esbuild": "^0.13.15",
+    "eslint": "^8.16.0",
+    "glob": "^8.0.3",
+    "mocha": "^10.0.0",
+    "source-map-support": "0.5.21",
+    "vsce": "^2.8.0"
+  },
+  "dependencies": {
+    "const-name": "0.1.0",
+    "lodash": "^4.17.21",
+    "typescript": "^4.6.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"vsce": "^2.8.0"
 	},
 	"dependencies": {
-		"const-name": "0.0.1",
+		"const-name": "0.1.0",
 		"lodash": "^4.17.21",
 		"typescript": "^4.6.4"
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,11 +3,13 @@ import * as vsc from 'vscode'
 import * as ts from 'typescript'
 import { PostfixCompletionProvider } from './postfixCompletionProvider'
 import { notCommand, NOT_COMMAND } from './notCommand'
+import { registerConstNameApi } from './utils/registerConstNameApi'
 
 let completionProvider: vsc.Disposable
 
 export function activate (context: vsc.ExtensionContext): void {
   registerCompletionProvider(context)
+  registerConstNameApi()
 
   context.subscriptions.push(vsc.commands.registerTextEditorCommand(NOT_COMMAND, async (editor: vsc.TextEditor, _: vsc.TextEditorEdit, ...args: ts.BinaryExpression[]) => {
     const [...expressions] = args

--- a/src/templates/forTemplates.ts
+++ b/src/templates/forTemplates.ts
@@ -43,8 +43,8 @@ export class ForTemplate extends BaseForTemplate {
 }
 
 const getArrayItemName = (node: ts.Node) => {
-  const deriveVariableName = vsc.workspace.getConfiguration('postfix', null).get<boolean>('deriveVariableName')
-  return (deriveVariableName ? getSingularFormFromExpression(node.getText())?.replace(/\$/g, '\\$') : undefined) ?? 'item';
+  const inferVariableName = vsc.workspace.getConfiguration('postfix', null).get<boolean>('inferVariableName')
+  return (inferVariableName ? getSingularFormFromExpression(node.getText())?.replace(/\$/g, '\\$') : undefined) ?? 'item';
 }
 
 export class ForOfTemplate extends BaseForTemplate {

--- a/src/templates/varTemplates.ts
+++ b/src/templates/varTemplates.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript'
 import * as vsc from 'vscode'
-import * as _ from 'lodash'
 import { getVariableNameFromCallExpresion } from 'const-name'
 import { CompletionItemBuilder } from '../completionItemBuilder'
 import { BaseExpressionTemplate } from './baseTemplates'

--- a/src/templates/varTemplates.ts
+++ b/src/templates/varTemplates.ts
@@ -14,9 +14,9 @@ export class VarTemplate extends BaseExpressionTemplate {
   buildCompletionItem(node: ts.Node, indentSize?: number) {
     let varName: string
 
-    const deriveVariableName = vsc.workspace.getConfiguration('postfix', null).get<boolean>('deriveVariableName')
+    const inferVariableName = vsc.workspace.getConfiguration('postfix', null).get<boolean>('inferVariableName')
     const expr = node.getText();
-    varName = deriveVariableName ?
+    varName = inferVariableName ?
       expr.startsWith('new') ?
         _.lowerFirst(
           clipByLastIndex(/(.+?)\(/.exec(expr)[1], [' ', '.'])

--- a/src/utils/registerConstNameApi.ts
+++ b/src/utils/registerConstNameApi.ts
@@ -1,0 +1,15 @@
+import * as _ from 'lodash'
+import { ExperimentalExternalGlobalApiEntry } from 'const-name'
+
+export const registerConstNameApi = () => {
+  if (!globalThis.__API_CONST_NAME_VAR_CALL) {
+    globalThis.__API_CONST_NAME_VAR_CALL = []
+  }
+  globalThis.__API_CONST_NAME_VAR_CALL.push({
+    handler(fullExpression, lastPartExpression) {
+      if (fullExpression.startsWith('new')) {
+        return _.lowerFirst(lastPartExpression)
+      }
+    }
+  } as ExperimentalExternalGlobalApiEntry)
+}

--- a/test/extension.singleline.test.ts
+++ b/test/extension.singleline.test.ts
@@ -5,6 +5,9 @@ import { describe, before, after } from 'mocha';
 const config = vsc.workspace.getConfiguration('postfix')
 
 describe('Single line template tests', () => {
+  before((done) => {
+    config.update('deriveVariableName', false, true).then(done, done)
+  })
   Test('not template - already negated expression | !expr{not}               >> expr')
   Test('let template - binary expression          | a * 3{let}               >> let name = a * 3')
   Test('let template - method call                | obj.call(){let}          >> let name = obj.call()')
@@ -75,6 +78,18 @@ describe('Single line template tests', () => {
   QuickPick('not template - complex conditions - first expression - alt  | if (a > b && x * 100{not}) {} >> if(a>b&&!(x*100)){}', true, 0)
   QuickPick('not template - complex conditions - second expression - alt | if (a > b && x * 100{not}) {} >> if(a<=b||!(x*100)){}', true, 1)
   QuickPick('not template - complex conditions - cancel quick pick - alt | if (a > b && x * 100{not}) {} >> if(a>b&&x*100.){}', true, 0, true)
+
+  describe('Derive variable name', () => {
+    before((done) => {
+      config.update('deriveVariableName', true, true).then(done, done)
+    })
+    Test('let template with name - new expression  | new Type(1, 2, 3){let}           >> let type = new Type(1, 2, 3)')
+    Test('let template with name - call expression | getSomethingCool(1, 2, 3){let}   >> let somethingCool = getSomethingCool(1, 2, 3)')
+    Test('forof template with array item name      | usersList{forof}                 >> for(letuserofusersList){}', true)
+    after((done) => {
+      config.update('deriveVariableName', false, true).then(done, done)
+    })
+  })
 
   describe('undefined templates in `typeof` mode', () => {
     before(setUndefinedMode(config, 'Typeof'))

--- a/test/extension.singleline.test.ts
+++ b/test/extension.singleline.test.ts
@@ -6,7 +6,7 @@ const config = vsc.workspace.getConfiguration('postfix')
 
 describe('Single line template tests', () => {
   before((done) => {
-    config.update('deriveVariableName', false, true).then(done, done)
+    config.update('inferVariableName', false, true).then(done, done)
   })
   Test('not template - already negated expression | !expr{not}               >> expr')
   Test('let template - binary expression          | a * 3{let}               >> let name = a * 3')
@@ -81,13 +81,13 @@ describe('Single line template tests', () => {
 
   describe('Derive variable name', () => {
     before((done) => {
-      config.update('deriveVariableName', true, true).then(done, done)
+      config.update('inferVariableName', true, true).then(done, done)
     })
     Test('let template with name - new expression  | new Type(1, 2, 3){let}           >> let type = new Type(1, 2, 3)')
     Test('let template with name - call expression | getSomethingCool(1, 2, 3){let}   >> let somethingCool = getSomethingCool(1, 2, 3)')
     Test('forof template with array item name      | usersList{forof}                 >> for(letuserofusersList){}', true)
     after((done) => {
-      config.update('deriveVariableName', false, true).then(done, done)
+      config.update('inferVariableName', false, true).then(done, done)
     })
   })
 


### PR DESCRIPTION
fixes #63

You can look at [tests](https://github.com/zardoy/const-name/blob/HEAD/src/index.spec.ts) to see what I got for you. You can also look for published files [here](https://cdn.jsdelivr.net/npm/const-name/).
I'm really really happy with that, but I'm planning to also derive name from JSDoc param (to let lib maitainers override name) and type information e.g. `const elem = document.querySelector()` (`elem` for `ParentNode['querySelector']`). I'm still not sure how I should maintain extractor and map for types, so I'm not going to do this at the moment.

As you can see I was also experimenting with public API. It is extremely simple and not the best one, but I left it enabled here so we can continue experimenting with the deriving const names. I can remove this all (but we will continue to use patched extension in this case).

No magic, everything is simple. Only regexs, so everything should be also fast. Feel free to ask.