### PR TITLE
Snippets vars fixes

### DIFF
--- a/src/completionItemBuilder.ts
+++ b/src/completionItemBuilder.ts
@@ -45,7 +45,7 @@ export class CompletionItemBuilder {
       new vsc.Position(nodeEnd.line, nodeEnd.character + 1) // accomodate 1 character for the dot
     )
 
-    const useSnippets = /(?<!\\)\$\{?\d/.test(replacement)
+    const useSnippets = /(?<!\\)\$/.test(replacement)
 
     if (useSnippets) {
       const escapedCode = this.code.replace(/\$/g, '\\$')
@@ -57,7 +57,7 @@ export class CompletionItemBuilder {
     } else {
       this.item.insertText = ''
       this.item.additionalTextEdits = [
-        vsc.TextEdit.replace(rangeToDelete, this.replaceExpression(replacement, this.code))
+        vsc.TextEdit.replace(rangeToDelete, this.replaceExpression(replacement.replace(/\\\$/g, '$$'), this.code))
       ]
     }
 

--- a/test/extension.singleline.test.ts
+++ b/test/extension.singleline.test.ts
@@ -168,6 +168,18 @@ describe('Single line template tests', () => {
     run('identifier', 'EXPR{custom}           | EXPR{custom}        >> EXPR')
     run('identifier', 'eXPr{custom}           | eXPr{custom}        >> EXPr')
   })
+
+  describe('custom template with snippet variables', () => {
+    const run = runWithCustomTemplate('console.log($TM_LINE_NUMBER, {{expr}})')
+
+    run('identifier', 'expr{custom}           | expr{custom}        >> console.log(1, expr)')
+  })
+
+  describe('custom template with escaped variable syntax', () => {
+    const run = runWithCustomTemplate('console.log("\\$TM_LINE_NUMBER", \\$1.{{expr}})')
+
+    run('identifier', 'expr{custom}           | expr{custom}        >> console.log("$TM_LINE_NUMBER", $1.expr)')
+  })
 })
 
 function runWithCustomTemplate(template: string) {


### PR DESCRIPTION
closes https://github.com/ipatalas/vscode-postfix-ts/pull/73

I also found that by introducing workaround in last PR I broke a way to insert literally `$`, fixed along with the tests to ensure we won't break it again.