### PR TITLE
Better workaround for `assignments`

### DIFF
--- a/src/postfixCompletionProvider.ts
+++ b/src/postfixCompletionProvider.ts
@@ -86,7 +86,28 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
 
     const binaryExpression = this.findClosestParent(node, ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression;
 
-    if (binaryExpression && binaryExpression.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
+    if (binaryExpression && ![
+      ts.SyntaxKind.EqualsToken,
+      ts.SyntaxKind.PlusEqualsToken,
+      ts.SyntaxKind.MinusEqualsToken,
+      ts.SyntaxKind.SlashEqualsToken,
+      ts.SyntaxKind.AsteriskEqualsToken,
+      ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+      ts.SyntaxKind.AmpersandEqualsToken,
+      // Bitwise assignments
+      ts.SyntaxKind.BarEqualsToken,
+      ts.SyntaxKind.BarBarEqualsToken,
+      ts.SyntaxKind.CaretEqualsToken,
+      ts.SyntaxKind.LessThanLessThanToken,
+      ts.SyntaxKind.LessThanLessThanEqualsToken,
+      ts.SyntaxKind.GreaterThanEqualsToken,
+      ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+      ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+      // relativly new
+      ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+      ts.SyntaxKind.QuestionQuestionToken,
+      ts.SyntaxKind.BarBarEqualsToken,
+    ].includes(binaryExpression.operatorToken.kind)) {
       return binaryExpression
     }
 


### PR DESCRIPTION
Its now should be a bit better for expressions like `a += a.castas`.

However I'm still not pleasred with workaround as `a && a.castas` would wrap the binary expression, but I expect it to wrap `identifier` instead. Its ok for `if` but not for identifier postfixes.

So I'm not sure wether it should be merged, maybe there is cleaner solution. I especially like `ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken` which it the longest token in ts.