### PR TITLE
Fix incorrect multiline indentation inserting non-snippet text

### DIFF
--- a/src/completionItemBuilder.ts
+++ b/src/completionItemBuilder.ts
@@ -45,7 +45,8 @@ export class CompletionItemBuilder {
       new vsc.Position(nodeEnd.line, nodeEnd.character + 1) // accomodate 1 character for the dot
     )
 
-    const useSnippets = /(?<!\\)\$/.test(replacement)
+    // const useSnippets = /(?<!\\)\$/.test(replacement)
+    const useSnippets = true
 
     if (useSnippets) {
       const escapedCode = this.code.replace(/\$/g, '\\$')

--- a/src/postfixCompletionProvider.ts
+++ b/src/postfixCompletionProvider.ts
@@ -43,6 +43,7 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
     }
 
     const indentSize = this.getIndentSize(document, currentNode)
+    const leadingWhitespace = this.getLeadingWhitespace(document, currentNode)
     const replacementNode = this.getNodeForReplacement(currentNode)
 
     try {
@@ -56,7 +57,7 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
 
           return canUseTemplate
         })
-        .flatMap(t => t.buildCompletionItem(replacementNode, indentSize))
+        .flatMap(t => t.buildCompletionItem(replacementNode, { indentSize, leadingWhitespace }))
     } catch (err) {
       console.error('Error while building postfix autocomplete items:')
       console.error(err)
@@ -118,6 +119,12 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
     if (AllSpaces.test(whitespaces)) {
       return whitespaces.length / (vsc.window.activeTextEditor.options.tabSize as number)
     }
+  }
+
+  private getLeadingWhitespace(document: vsc.TextDocument, node: ts.Node) {
+    const source = node.getSourceFile();
+    const { line } = source.getLineAndCharacterOfPosition(node.getStart(source))
+    return document.lineAt(line).text.match(/^\s*/)?.[0]
   }
 
   private shouldBeIgnored(document: vsc.TextDocument, position: vsc.Position) {

--- a/src/postfixCompletionProvider.ts
+++ b/src/postfixCompletionProvider.ts
@@ -1,7 +1,7 @@
 import * as vsc from 'vscode'
 import * as ts from 'typescript'
 
-import { IPostfixTemplate } from './template'
+import { IndentInfo, IPostfixTemplate } from './template'
 import { AllTabs, AllSpaces } from './utils/multiline-expressions'
 import { loadBuiltinTemplates, loadCustomTemplates } from './utils/templates'
 import { findClosestParent, findNodeAtPosition } from './utils/typescript'
@@ -42,8 +42,7 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
       return []
     }
 
-    const indentSize = this.getIndentSize(document, currentNode)
-    const leadingWhitespace = this.getLeadingWhitespace(document, currentNode)
+    const indentInfo = this.getIndentInfo(document, currentNode)
     const replacementNode = this.getNodeForReplacement(currentNode)
 
     try {
@@ -57,7 +56,7 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
 
           return canUseTemplate
         })
-        .flatMap(t => t.buildCompletionItem(replacementNode, { indentSize, leadingWhitespace }))
+        .flatMap(t => t.buildCompletionItem(replacementNode, indentInfo))
     } catch (err) {
       console.error('Error while building postfix autocomplete items:')
       console.error(err)
@@ -105,26 +104,24 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
     return currentNode
   }
 
-  private getIndentSize(document: vsc.TextDocument, node: ts.Node): number | undefined {
+  private getIndentInfo(document: vsc.TextDocument, node: ts.Node): IndentInfo | undefined {
     const source = node.getSourceFile()
     const position = ts.getLineAndCharacterOfPosition(source, node.getStart(source))
 
     const line = document.lineAt(position.line)
     const whitespaces = line.text.substring(0, line.firstNonWhitespaceCharacterIndex)
+    let indentSize: number
 
     if (AllTabs.test(whitespaces)) {
-      return whitespaces.length
+      indentSize = whitespaces.length
+    } else if (AllSpaces.test(whitespaces)) {
+      indentSize = whitespaces.length / (vsc.window.activeTextEditor.options.tabSize as number)
     }
 
-    if (AllSpaces.test(whitespaces)) {
-      return whitespaces.length / (vsc.window.activeTextEditor.options.tabSize as number)
+    return {
+      indentSize,
+      leadingWhitespace: whitespaces
     }
-  }
-
-  private getLeadingWhitespace(document: vsc.TextDocument, node: ts.Node) {
-    const source = node.getSourceFile();
-    const { line } = source.getLineAndCharacterOfPosition(node.getStart(source))
-    return document.lineAt(line).text.match(/^\s*/)?.[0]
   }
 
   private shouldBeIgnored(document: vsc.TextDocument, position: vsc.Position) {

--- a/src/postfixCompletionProvider.ts
+++ b/src/postfixCompletionProvider.ts
@@ -104,13 +104,13 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
     return currentNode
   }
 
-  private getIndentInfo(document: vsc.TextDocument, node: ts.Node): IndentInfo | undefined {
+  private getIndentInfo(document: vsc.TextDocument, node: ts.Node): IndentInfo {
     const source = node.getSourceFile()
     const position = ts.getLineAndCharacterOfPosition(source, node.getStart(source))
 
     const line = document.lineAt(position.line)
     const whitespaces = line.text.substring(0, line.firstNonWhitespaceCharacterIndex)
-    let indentSize: number
+    let indentSize = 0
 
     if (AllTabs.test(whitespaces)) {
       indentSize = whitespaces.length

--- a/src/template.d.ts
+++ b/src/template.d.ts
@@ -4,7 +4,13 @@ import * as ts from 'typescript'
 export interface IPostfixTemplate {
   readonly templateName: string
 
-  buildCompletionItem(node: ts.Node, indentSize?: number): vsc.CompletionItem
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo): vsc.CompletionItem
 
   canUse(node: ts.Node): boolean
+}
+
+export interface IndentInfo {
+  indentSize?: number
+  /** Leading whitespace characters of the first line of replacing node */
+  leadingWhitespace?: string
 }

--- a/src/templates/baseTemplates.ts
+++ b/src/templates/baseTemplates.ts
@@ -1,12 +1,12 @@
 import * as ts from 'typescript'
 import * as vsc from 'vscode';
-import { IPostfixTemplate } from '../template'
+import { IndentInfo, IPostfixTemplate } from '../template'
 import { findClosestParent, isAssignmentBinaryExpression } from '../utils/typescript';
 
 export abstract class BaseTemplate implements IPostfixTemplate {
   constructor(public readonly templateName: string) {}
 
-  abstract buildCompletionItem(node: ts.Node, indentSize?: number): vsc.CompletionItem
+  abstract buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo): vsc.CompletionItem
   abstract canUse  (node: ts.Node) : boolean
 
   protected isSimpleExpression = (node: ts.Node) => ts.isExpressionStatement(node) && !this.isStringLiteral(node)
@@ -115,7 +115,7 @@ export abstract class BaseTemplate implements IPostfixTemplate {
 }
 
 export abstract class BaseExpressionTemplate extends BaseTemplate {
-  abstract override buildCompletionItem(node: ts.Node, indentSize?: number)
+  abstract override buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo)
 
   canUse(node: ts.Node) {
     return !this.inIfStatement(node) && !this.isTypeNode(node) && !this.inAssignmentStatement(node) &&

--- a/src/templates/castTemplates.ts
+++ b/src/templates/castTemplates.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript'
 import { CompletionItemBuilder } from '../completionItemBuilder'
+import { IndentInfo } from '../template'
 import { BaseExpressionTemplate } from './baseTemplates'
 
 export class CastTemplate extends BaseExpressionTemplate {
@@ -7,8 +8,8 @@ export class CastTemplate extends BaseExpressionTemplate {
     super(keyword)
   }
 
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
-    const completionitembuilder = CompletionItemBuilder.create(this.keyword, node, indentSize)
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
+    const completionitembuilder = CompletionItemBuilder.create(this.keyword, node, indentInfo)
 
     if (this.keyword === 'castas') {
       return completionitembuilder

--- a/src/templates/consoleTemplates.ts
+++ b/src/templates/consoleTemplates.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript'
 import { CompletionItemBuilder } from '../completionItemBuilder'
+import { IndentInfo } from '../template'
 import { BaseExpressionTemplate } from './baseTemplates'
 
 export class ConsoleTemplate extends BaseExpressionTemplate {
@@ -8,11 +9,11 @@ export class ConsoleTemplate extends BaseExpressionTemplate {
     super(level)
   }
 
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo: IndentInfo) {
     node = this.unwindBinaryExpression(node)
 
     return CompletionItemBuilder
-      .create(this.level, node, indentSize)
+      .create(this.level, node, indentInfo)
       .replace(`console.${this.level}({{expr}})`)
       .build()
   }

--- a/src/templates/customTemplate.ts
+++ b/src/templates/customTemplate.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript'
 import { BaseTemplate } from './baseTemplates'
 import { CompletionItemBuilder } from '../completionItemBuilder'
+import { IndentInfo } from '../template'
 
 export class CustomTemplate extends BaseTemplate {
   private conditionsMap = new Map<string, (node: ts.Node) => boolean>([
@@ -18,13 +19,13 @@ export class CustomTemplate extends BaseTemplate {
     super(name)
   }
 
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     if (this.when.includes('binary-expression')) {
       node = this.unwindBinaryExpression(node)
     }
 
     return CompletionItemBuilder
-      .create(this.templateName, node, indentSize)
+      .create(this.templateName, node, indentInfo)
       .description(this.description)
       .replace(this.body)
       .build()

--- a/src/templates/forTemplates.ts
+++ b/src/templates/forTemplates.ts
@@ -3,6 +3,7 @@ import { CompletionItemBuilder } from '../completionItemBuilder'
 import { BaseTemplate } from './baseTemplates'
 import { getConfigValue, getIndentCharacters, getPlaceholderWithOptions } from '../utils'
 import { inferForVarTemplate } from '../utils/infer-names';
+import { IndentInfo } from '../template';
 
 abstract class BaseForTemplate extends BaseTemplate {
   canUse(node: ts.Node): boolean {
@@ -24,13 +25,13 @@ abstract class BaseForTemplate extends BaseTemplate {
 }
 
 export class ForTemplate extends BaseForTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     const isAwaited = node.parent && ts.isAwaitExpression(node.parent)
     const prefix = isAwaited ? '(' : ''
     const suffix = isAwaited ? ')' : ''
 
     return CompletionItemBuilder
-      .create('for', node, indentSize)
+      .create('for', node, indentInfo)
       .replace(`for (let \${1:i} = 0; \${1} < \${2:${prefix}{{expr}}${suffix}}.length; \${1}++) {\n${getIndentCharacters()}\${0}\n}`)
       .build()
   }
@@ -49,25 +50,25 @@ const getArrayItemNames = (node: ts.Node): string[] => {
 }
 
 export class ForOfTemplate extends BaseForTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     const itemNames = getArrayItemNames(node)
 
     return CompletionItemBuilder
-      .create('forof', node, indentSize)
+      .create('forof', node, indentInfo)
       .replace(`for (let ${getPlaceholderWithOptions(itemNames)} of \${2:{{expr}}}) {\n${getIndentCharacters()}\${0}\n}`)
       .build()
   }
 }
 
 export class ForEachTemplate extends BaseForTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     const isAwaited = node.parent && ts.isAwaitExpression(node.parent)
     const prefix = isAwaited ? '(' : ''
     const suffix = isAwaited ? ')' : ''
     const itemNames = getArrayItemNames(node)
 
     return CompletionItemBuilder
-      .create('foreach', node, indentSize)
+      .create('foreach', node, indentInfo)
       .replace(`${prefix}{{expr}}${suffix}.forEach(${getPlaceholderWithOptions(itemNames)} => \${2})`)
       .build()
   }

--- a/src/templates/ifTemplates.ts
+++ b/src/templates/ifTemplates.ts
@@ -3,6 +3,7 @@ import { CompletionItemBuilder } from '../completionItemBuilder'
 import { BaseExpressionTemplate } from './baseTemplates'
 import { getConfigValue, getIndentCharacters } from '../utils'
 import { invertExpression } from '../utils/invert-expression'
+import { IndentInfo } from '../template'
 
 abstract class BaseIfElseTemplate extends BaseExpressionTemplate {
   override canUse(node: ts.Node) {
@@ -15,24 +16,24 @@ abstract class BaseIfElseTemplate extends BaseExpressionTemplate {
 }
 
 export class IfTemplate extends BaseIfElseTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     node = this.unwindBinaryExpression(node, false)
     const replacement = this.unwindBinaryExpression(node, true).getText()
 
     return CompletionItemBuilder
-      .create('if', node, indentSize)
+      .create('if', node, indentInfo)
       .replace(`if (${replacement}) {\n${getIndentCharacters()}\${0}\n}`)
       .build()
   }
 }
 
 export class ElseTemplate extends BaseIfElseTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     node = this.unwindBinaryExpression(node, false)
     const replacement = invertExpression(this.unwindBinaryExpression(node, true));
 
     return CompletionItemBuilder
-      .create('else', node, indentSize)
+      .create('else', node, indentInfo)
       .replace(`if (${replacement}) {\n${getIndentCharacters()}\${0}\n}`)
       .build()
   }
@@ -54,9 +55,9 @@ export class IfEqualityTemplate extends BaseIfElseTemplate {
     return super.canUse(node) && !this.isBinaryExpression(node)
   }
 
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     return CompletionItemBuilder
-      .create(this.keyword, node, indentSize)
+      .create(this.keyword, node, indentInfo)
       .replace(`if ({{expr}} ${this.operator} ${this.operand}) {\n${getIndentCharacters()}\${0}\n}`)
       .build()
   }
@@ -76,9 +77,9 @@ export class IfTypeofEqualityTemplate extends BaseIfElseTemplate {
     return super.canUse(node) && !this.isBinaryExpression(node)
   }
 
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     return CompletionItemBuilder
-      .create(this.keyword, node, indentSize)
+      .create(this.keyword, node, indentInfo)
       .replace(`if (typeof {{expr}} ${this.operator} "${this.operand}") {\n${getIndentCharacters()}\${0}\n}`)
       .build()
   }

--- a/src/templates/newTemplate.ts
+++ b/src/templates/newTemplate.ts
@@ -1,11 +1,12 @@
 import * as ts from 'typescript'
 import { CompletionItemBuilder } from '../completionItemBuilder'
+import { IndentInfo } from '../template'
 import { BaseTemplate } from './baseTemplates'
 
 export class NewTemplate extends BaseTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     return CompletionItemBuilder
-      .create('new', node, indentSize)
+      .create('new', node, indentInfo)
       .replace('new {{expr}}($0)')
       .build()
   }

--- a/src/templates/notTemplate.ts
+++ b/src/templates/notTemplate.ts
@@ -3,13 +3,14 @@ import { CompletionItemBuilder } from '../completionItemBuilder'
 import { BaseTemplate } from './baseTemplates'
 import { NOT_COMMAND } from '../notCommand'
 import { invertExpression } from '../utils/invert-expression'
+import { IndentInfo } from '../template'
 
 export class NotTemplate extends BaseTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     node = this.normalizeBinaryExpression(node)
 
     const completionBuilder = CompletionItemBuilder
-      .create('not', node, indentSize)
+      .create('not', node, indentInfo)
 
     if (this.isBinaryExpression(node)) {
       const expressions = this.getBinaryExpressions(node)
@@ -26,7 +27,7 @@ export class NotTemplate extends BaseTemplate {
       }
     }
 
-    const replacement = invertExpression(node, undefined, indentSize)
+    const replacement = invertExpression(node, undefined, indentInfo?.indentSize)
     return completionBuilder
       .replace(replacement)
       .build()

--- a/src/templates/promisifyTemplate.ts
+++ b/src/templates/promisifyTemplate.ts
@@ -1,11 +1,12 @@
 import * as ts from 'typescript'
 import { CompletionItemBuilder } from '../completionItemBuilder'
+import { IndentInfo } from '../template'
 import { BaseTemplate } from './baseTemplates'
 
 export class PromisifyTemplate extends BaseTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     return CompletionItemBuilder
-      .create('promisify', node, indentSize)
+      .create('promisify', node, indentInfo)
       .replace('Promise<{{expr}}>')
       .build()
   }

--- a/src/templates/returnTemplate.ts
+++ b/src/templates/returnTemplate.ts
@@ -1,13 +1,14 @@
 import * as ts from 'typescript'
 import { CompletionItemBuilder } from '../completionItemBuilder'
+import { IndentInfo } from '../template'
 import { BaseExpressionTemplate } from './baseTemplates'
 
 export class ReturnTemplate extends BaseExpressionTemplate {
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     node = this.unwindBinaryExpression(node)
 
     return CompletionItemBuilder
-      .create('return', node, indentSize)
+      .create('return', node, indentInfo)
       .replace('return {{expr}}')
       .build()
   }

--- a/src/templates/varTemplates.ts
+++ b/src/templates/varTemplates.ts
@@ -3,20 +3,21 @@ import { CompletionItemBuilder } from '../completionItemBuilder'
 import { BaseExpressionTemplate } from './baseTemplates'
 import { getConfigValue, getPlaceholderWithOptions } from '../utils'
 import { inferVarTemplateName } from '../utils/infer-names'
+import { IndentInfo } from '../template'
 
 export class VarTemplate extends BaseExpressionTemplate {
   constructor(private keyword: 'var' | 'let' | 'const') {
     super(keyword)
   }
 
-  buildCompletionItem(node: ts.Node, indentSize?: number) {
+  buildCompletionItem(node: ts.Node, indentInfo?: IndentInfo) {
     node = this.unwindBinaryExpression(node)
 
     const inferVarNameEnabled = getConfigValue<boolean>('inferVariableName')
     const suggestedVarNames = (inferVarNameEnabled ? inferVarTemplateName(node) : undefined) ?? ['name']
 
     return CompletionItemBuilder
-      .create(this.keyword, node, indentSize)
+      .create(this.keyword, node, indentInfo)
       .replace(`${this.keyword} ${getPlaceholderWithOptions(suggestedVarNames)} = {{expr}}$0`)
       .build()
   }

--- a/src/utils/multiline-expressions.ts
+++ b/src/utils/multiline-expressions.ts
@@ -41,3 +41,7 @@ function stripLineIndent(line: string, indentSize: number) {
 
   return line
 }
+
+export const adjustLeadingWhitespace = (content: string, leadingWhitespace = '') => {
+  return content.split(/\r?\n/).map((line, i) => !i ? line : leadingWhitespace+line).join('\n')
+}

--- a/test/extension.multiline.test.ts
+++ b/test/extension.multiline.test.ts
@@ -37,25 +37,25 @@ describe('Multiline template tests', () => {
       | \t  .lastOne(){let} >> \t\t  .lastOne()`)
 
   Test(`return template - method call (indentation - tabs)
-      | \t\tobject.call()     >> \t\treturn object.call()
-      | \t\t\t.anotherCall()  >> \t\t\t.anotherCall()
+      | \t\tobject.call()        >> \t\treturn object.call()
+      | \t\t\t.anotherCall()     >> \t\t\t.anotherCall()
       | \t\t\t.lastOne(){return} >> \t\t\t.lastOne()`)
 
   // first line gets to keep original indentation in VSCode
   Test(`return template - method call (indentation - spaces)
-      | ${indent(2)}object.call()   >> ${indent(2)}return object.call()
-      | ${indent(3)}.anotherCall()  >> \t\t\t.anotherCall()
+      | ${indent(2)}object.call()      >> ${indent(2)}return object.call()
+      | ${indent(3)}.anotherCall()     >> \t\t\t.anotherCall()
       | ${indent(3)}.lastOne(){return} >> \t\t\t.lastOne()`)
 
   Test(`return template - method call (indentation - mixed)
-      | \t\tobject.call()          >> \t\treturn object.call()
-      | ${indent(3)}.anotherCall() >> \t\t\t.anotherCall()
+      | \t\tobject.call()             >> \t\treturn object.call()
+      | ${indent(3)}.anotherCall()    >> \t\t\t.anotherCall()
       | \t\t\t.lastOne(){return}      >> \t\t\t.lastOne()`)
 
   Test(`return template - method call (indentation - completely mixed)
-      | \tobject.call()     >> \treturn object.call()
-      | \t  .anotherCall()  >> \t  .anotherCall()
-      | \t  .lastOne(){return} >> \t  .lastOne()`)
+      | \tobject.call()        >> \treturn object.call()
+      | \t  .anotherCall()     >> \t\t  .anotherCall()
+      | \t  .lastOne(){return} >> \t\t  .lastOne()`)
 
   Test(`let template - property access expression
       | object.   >> let name = object.

--- a/test/extension.multiline.test.ts
+++ b/test/extension.multiline.test.ts
@@ -48,6 +48,32 @@ describe('Multiline template tests', () => {
       | \t.b        >> \t.b
       | \t.c++{let} >> \t.c++`)
 
+  Test(`return template - method call (equal indentation)
+      | \tobject.call() >> \treturn object.call()
+      | .anotherCall()  >> \t.anotherCall()
+      | .lastOne(){return} >> \t.lastOne()`)
+
+  Test(`return template - method call (indentation - tabs)
+      | \t\tobject.call()     >> \t\treturn object.call()
+      | \t\t\t.anotherCall()  >> \t\t\t.anotherCall()
+      | \t\t\t.lastOne(){return} >> \t\t\t.lastOne()`)
+
+  // first line gets to keep original indentation in VSCode
+  Test(`return template - method call (indentation - spaces)
+      | ${indent(2)}object.call()   >> ${indent(2)}return object.call()
+      | ${indent(3)}.anotherCall()  >> \t\t\t.anotherCall()
+      | ${indent(3)}.lastOne(){return} >> \t\t\t.lastOne()`)
+
+  Test(`return template - method call (indentation - mixed)
+      | \t\tobject.call()          >> \t\treturn object.call()
+      | ${indent(3)}.anotherCall() >> \t\t\t.anotherCall()
+      | \t\t\t.lastOne(){return}      >> \t\t\t.lastOne()`)
+
+  Test(`return template - method call (indentation - compreturnely mixed)
+      | \tobject.call()     >> \treturn object.call()
+      | \t  .anotherCall()  >> \t\t  .anotherCall()
+      | \t  .lastOne(){return} >> \t\t  .lastOne()`)
+
   Test(`return template - new expression
       | new Type(    >> return new Type(
       | \t1,         >> \t1,

--- a/test/extension.multiline.test.ts
+++ b/test/extension.multiline.test.ts
@@ -90,7 +90,7 @@ describe('Multiline template tests', () => {
       | ${indent(3)}.anotherCall() >> \t\t\t.anotherCall()
       | \t\t\t.lastOne(){return}      >> \t\t\t.lastOne()`)
 
-  Test(`return template - method call (indentation - compreturnely mixed)
+  Test(`return template - method call (indentation - completely mixed)
       | \tobject.call()     >> \treturn object.call()
       | \t  .anotherCall()  >> \t\t  .anotherCall()
       | \t  .lastOne(){return} >> \t\t  .lastOne()`)

--- a/test/extension.multiline.test.ts
+++ b/test/extension.multiline.test.ts
@@ -74,27 +74,6 @@ describe('Multiline template tests', () => {
       | .anotherCall()  >> \t.anotherCall()
       | .lastOne(){return} >> \t.lastOne()`)
 
-  Test(`return template - method call (indentation - tabs)
-      | \t\tobject.call()     >> \t\treturn object.call()
-      | \t\t\t.anotherCall()  >> \t\t\t.anotherCall()
-      | \t\t\t.lastOne(){return} >> \t\t\t.lastOne()`)
-
-  // first line gets to keep original indentation in VSCode
-  Test(`return template - method call (indentation - spaces)
-      | ${indent(2)}object.call()   >> ${indent(2)}return object.call()
-      | ${indent(3)}.anotherCall()  >> \t\t\t.anotherCall()
-      | ${indent(3)}.lastOne(){return} >> \t\t\t.lastOne()`)
-
-  Test(`return template - method call (indentation - mixed)
-      | \t\tobject.call()          >> \t\treturn object.call()
-      | ${indent(3)}.anotherCall() >> \t\t\t.anotherCall()
-      | \t\t\t.lastOne(){return}      >> \t\t\t.lastOne()`)
-
-  Test(`return template - method call (indentation - completely mixed)
-      | \tobject.call()     >> \treturn object.call()
-      | \t  .anotherCall()  >> \t\t  .anotherCall()
-      | \t  .lastOne(){return} >> \t\t  .lastOne()`)
-
   Test(`return template - new expression
       | new Type(    >> return new Type(
       | \t1,         >> \t1,

--- a/test/extension.multiline.test.ts
+++ b/test/extension.multiline.test.ts
@@ -1,5 +1,5 @@
 import { runTestMultiline as Test, runTestMultilineQuickPick as QuickPick } from './runner'
-import { TabSize } from './utils'
+import { runWithCustomTemplate, TabSize } from './utils'
 import { describe } from 'mocha';
 
 const indent = (size: number) => ' '.repeat(size * TabSize)
@@ -79,6 +79,15 @@ describe('Multiline template tests', () => {
       | \t1,         >> \t1,
       | \t2,         >> \t2,
       | \t3){return} >> \t3)`)
+
+  describe('Without {{expr}}', () => {
+    const run = runWithCustomTemplate('1\n\t1\n1')
+
+    run('expression', `indentation - completely mixed
+      | \tobject.call()        >> \t1
+      | \t  .anotherCall()     >> \t\t1
+      | \t  .lastOne{custom}   >> \t1`)
+  })
 
   Test(`let template - method call in return object method
       | function hoge() {   >> function hoge() {

--- a/test/extension.singleline.test.ts
+++ b/test/extension.singleline.test.ts
@@ -1,6 +1,7 @@
 import * as vsc from 'vscode'
 import { runTest as Test, runTestQuickPick as QuickPick } from './runner'
 import { describe, before, after } from 'mocha';
+import { runWithCustomTemplate } from './utils';
 
 const config = vsc.workspace.getConfiguration('postfix')
 
@@ -192,36 +193,9 @@ describe('Single line template tests', () => {
   })
 })
 
-function runWithCustomTemplate(template: string) {
-  return (when: string, ...tests: string[]) =>
-    describe(when, () => {
-      before(setCustomTemplate(config, 'custom', template, [when]))
-      after(resetCustomTemplates(config))
-
-      tests.forEach(t => Test(t))
-    })
-}
-
 function setUndefinedMode(config: vsc.WorkspaceConfiguration, value: 'Equal' | 'Typeof' | undefined) {
   return (done: Mocha.Done) => {
     config.update('undefinedMode', value, true).then(done, done)
-  }
-}
-
-function setCustomTemplate(config: vsc.WorkspaceConfiguration, name: string, body: string, when: string[]) {
-  return (done: Mocha.Done) => {
-    config.update('customTemplates', [{
-      'name': name,
-      'body': body,
-      'description': 'custom description',
-      'when': when
-    }], true).then(done, done)
-  }
-}
-
-function resetCustomTemplates(config: vsc.WorkspaceConfiguration) {
-  return (done: Mocha.Done) => {
-    config.update('customTemplates', undefined, true).then(done, done)
   }
 }
 


### PR DESCRIPTION
I added failing tests to illustrate the problem.

I tried different approaches, and it seems only `insertText` of completion and `editor.insertText` does whitespace adjusting in VSCode. First one causes [editor scroll jump higher](https://github.com/ipatalas/vscode-postfix-ts/pull/73), and a second one messes up with undo stack. So I tried to do whitespace normalization manually, however:

1. It doesn't seem to be logical that we first remove all whitespace characters (`adjustMultilineIndentation`) and then add them back (code that adds this pr).
2. There is an issue with `.not`:

```ts
    if (
        a && (b &&
        a
        .a
        .b).not
    )  {}
```