### PR TITLE
strip indentation in `not` quickpick

### DIFF
--- a/src/notCommand.ts
+++ b/src/notCommand.ts
@@ -6,10 +6,10 @@ export const NOT_COMMAND = 'complete.notTemplate'
 
 export function notCommand(editor: vsc.TextEditor, expressions: ts.BinaryExpression[]) {
   return vsc.window.showQuickPick(expressions.map(node => ({
-    label: node.getText(),
+    label: node.getText().replace(/\s+/g, ' '),
     description: '',
     detail: 'Invert this expression',
-    node: node
+    node
   })))
     .then(value => {
       if (!value) {


### PR DESCRIPTION
Before:

<img width="500" alt="Screenshot 2022-09-22 at 20 40 20" src="https://user-images.githubusercontent.com/46503702/191815748-a2511684-cf1e-4a6b-a317-0e8e5d30841a.png">
After:
<img width="500" alt="Screenshot 2022-09-22 at 20 41 10" src="https://user-images.githubusercontent.com/46503702/191815768-2a388665-c9eb-4325-b456-7eb9993681c4.png">