### PR TITLE
`not`: Dont treat assignments as binary expression globally and skip unnecesary scopes

### DIFF
--- a/src/postfixCompletionProvider.ts
+++ b/src/postfixCompletionProvider.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript'
 import { IndentInfo, IPostfixTemplate } from './template'
 import { AllTabs, AllSpaces } from './utils/multiline-expressions'
 import { loadBuiltinTemplates, loadCustomTemplates } from './utils/templates'
-import { findClosestParent, findNodeAtPosition } from './utils/typescript'
+import { findNodeAtPosition } from './utils/typescript'
 import { CustomTemplate } from './templates/customTemplate'
 import { getHtmlLikeEmbedText } from './htmlLikeSupport'
 
@@ -75,7 +75,7 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
   }
 
   private isTypeReference = (node: ts.Node) => {
-    const typeRef = findClosestParent(node, ts.SyntaxKind.TypeReference)
+    const typeRef = ts.findAncestor(node, ts.isTypeReferenceNode)
     return !!typeRef
   }
 
@@ -89,7 +89,7 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
     }
 
     if (ts.isQualifiedName(node.parent)) {
-      const typeRef = findClosestParent<ts.TypeReferenceNode>(node, ts.SyntaxKind.TypeReference)
+      const typeRef = ts.findAncestor(node, ts.isTypeReferenceNode)
 
       if (ts.isQualifiedName(typeRef.typeName)) {
         return typeRef.typeName.left
@@ -199,9 +199,9 @@ export class PostfixCompletionProvider implements vsc.CompletionItemProvider {
     }
 
     function isJsx(node: ts.Node) {
-      const jsx = findClosestParent(node, ts.SyntaxKind.JsxElement)
-      const jsxFragment = findClosestParent(node, ts.SyntaxKind.JsxFragment)
-      const jsxExpression = findClosestParent(node, ts.SyntaxKind.JsxExpression)
+      const jsx = ts.findAncestor(node, ts.isJsxElement)
+      const jsxFragment = ts.findAncestor(node, ts.isJsxFragment)
+      const jsxExpression = ts.findAncestor(node, ts.isJsxExpression)
 
       return (!!jsx || !!jsxFragment) && !jsxExpression
     }

--- a/src/templates/baseTemplates.ts
+++ b/src/templates/baseTemplates.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript'
 import * as vsc from 'vscode'
 import { IndentInfo, IPostfixTemplate } from '../template'
-import { findClosestParent, isAssignmentBinaryExpression, isStringLiteral } from '../utils/typescript'
+import { isAssignmentBinaryExpression, isStringLiteral } from '../utils/typescript'
 
 export abstract class BaseTemplate implements IPostfixTemplate {
   constructor(public readonly templateName: string) {}
@@ -67,7 +67,7 @@ export abstract class BaseTemplate implements IPostfixTemplate {
   protected unwindBinaryExpression = (node: ts.Node, removeParens = true) => {
     let binaryExpression = removeParens && ts.isParenthesizedExpression(node) && ts.isBinaryExpression(node.expression)
       ? node.expression
-      : findClosestParent(node, ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression
+      : ts.findAncestor(node, ts.isBinaryExpression)
 
     while (binaryExpression && ts.isBinaryExpression(binaryExpression.parent)) {
       binaryExpression = binaryExpression.parent

--- a/src/templates/baseTemplates.ts
+++ b/src/templates/baseTemplates.ts
@@ -56,11 +56,11 @@ export abstract class BaseTemplate implements IPostfixTemplate {
   }
 
   protected isBinaryExpression = (node: ts.Node) => {
-    if (ts.isBinaryExpression(node)) {
+    if (ts.isBinaryExpression(node) && !isAssignmentBinaryExpression(node)) {
       return true
     }
 
-    return ts.isParenthesizedExpression(node) && ts.isBinaryExpression(node.expression)
+    return ts.isParenthesizedExpression(node) && this.isBinaryExpression(node.expression)
       || node.parent && this.isBinaryExpression(node.parent)
   }
 

--- a/src/templates/baseTemplates.ts
+++ b/src/templates/baseTemplates.ts
@@ -60,7 +60,7 @@ export abstract class BaseTemplate implements IPostfixTemplate {
       return true
     }
 
-    return ts.isParenthesizedExpression(node) && this.isBinaryExpression(node.expression)
+    return ts.isParenthesizedExpression(node) && ts.isBinaryExpression(node.expression)
       || node.parent && this.isBinaryExpression(node.parent)
   }
 

--- a/src/templates/notTemplate.ts
+++ b/src/templates/notTemplate.ts
@@ -43,7 +43,7 @@ export class NotTemplate extends BaseTemplate {
         || this.isIdentifier(node))
   }
 
-  private isStrictEqualityOrInstanceofBinaryEpxression = (node: ts.Node) => {
+  private isStrictEqualityOrInstanceofBinaryExpression = (node: ts.Node) => {
     return ts.isBinaryExpression(node) && [
       ts.SyntaxKind.EqualsEqualsEqualsToken,
       ts.SyntaxKind.ExclamationEqualsEqualsToken,
@@ -72,7 +72,7 @@ export class NotTemplate extends BaseTemplate {
       return node
     }
 
-    if (this.isStrictEqualityOrInstanceofBinaryEpxression(node.parent)) {
+    if (this.isStrictEqualityOrInstanceofBinaryExpression(node.parent)) {
       return node.parent
     }
 

--- a/src/templates/notTemplate.ts
+++ b/src/templates/notTemplate.ts
@@ -43,6 +43,14 @@ export class NotTemplate extends BaseTemplate {
         || this.isIdentifier(node))
   }
 
+  private isStrictEqualityOrInstanceofBinaryEpxression = (node: ts.Node) => {
+    return ts.isBinaryExpression(node) && [
+      ts.SyntaxKind.EqualsEqualsEqualsToken,
+      ts.SyntaxKind.ExclamationEqualsEqualsToken,
+      ts.SyntaxKind.InstanceOfKeyword
+    ].includes(node.operatorToken.kind)
+  }
+
   private getBinaryExpressions = (node: ts.Node) => {
     const possibleExpressions = [node]
 
@@ -57,6 +65,14 @@ export class NotTemplate extends BaseTemplate {
 
   private normalizeBinaryExpression = (node: ts.Node) => {
     if (ts.isParenthesizedExpression(node.parent) && ts.isBinaryExpression(node.parent.expression)) {
+      return node.parent
+    }
+
+    if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) {
+      return node
+    }
+
+    if (this.isStrictEqualityOrInstanceofBinaryEpxression(node.parent)) {
       return node.parent
     }
 

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -47,7 +47,7 @@ export const isAssignmentBinaryExpression = (node: ts.BinaryExpression) => {
     ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
     // relatively new
     ts.SyntaxKind.AmpersandAmpersandEqualsToken,
-    ts.SyntaxKind.QuestionQuestionToken,
+    ts.SyntaxKind.QuestionQuestionEqualsToken,
     ts.SyntaxKind.BarBarEqualsToken,
   ].includes(node.operatorToken.kind)
 }

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -27,14 +27,6 @@ export const findNodeAtPosition = (source: ts.SourceFile, character: number): ts
   }
 }
 
-export const findClosestParent = <T extends ts.Node = ts.Node>(node: ts.Node, ...kind: ts.SyntaxKind[]): T | undefined => {
-  while (node && !kind.includes(node.kind)) {
-    node = node.parent
-  }
-
-  return node as T
-}
-
 export const isAssignmentBinaryExpression = (node: ts.BinaryExpression) => {
   return [
     ts.SyntaxKind.EqualsToken,

--- a/test/extension.singleline.test.ts
+++ b/test/extension.singleline.test.ts
@@ -82,6 +82,8 @@ describe('Single line template tests', () => {
   Test('new template - assignment binary expression | a = B{new}          >> a = new B()')
 
   Test('not template                                            | expr{not}                   >> !expr')
+  Test('not template - strict equality                          | if (a === b{not})           >> if (a !== b)')
+  Test('not template - instanceof                               | if (a instanceof b{not})    >> if (!(a instanceof b))')
   Test('not template - ??=                                      | a ??= b{not}                >> a ??= !b')
   Test('not template - with non-null assertion                  | expr!{not}                  >> !expr!')
   Test('not template - inside a call expression                 | call.expression(expr{not})  >> call.expression(!expr)')

--- a/test/extension.singleline.test.ts
+++ b/test/extension.singleline.test.ts
@@ -77,10 +77,12 @@ describe('Single line template tests', () => {
   Test('cast template   | expr{cast}   >> (<>expr)')
   Test('castas template | expr{castas} >> (expr as )')
 
-  Test('new template - identifier                 | Type{new}           >> new Type()')
-  Test('new template - property access expression | namespace.Type{new} >> new namespace.Type()')
+  Test('new template - identifier                   | Type{new}           >> new Type()')
+  Test('new template - property access expression   | namespace.Type{new} >> new namespace.Type()')
+  Test('new template - assignment binary expression | a = B{new}          >> a = new B()')
 
   Test('not template                                            | expr{not}                   >> !expr')
+  Test('not template - ??=                                      | a ??= b{not}                >> a ??= !b')
   Test('not template - with non-null assertion                  | expr!{not}                  >> !expr!')
   Test('not template - inside a call expression                 | call.expression(expr{not})  >> call.expression(!expr)')
   Test('not template - inside a call expression - negated       | call.expression(!expr{not}) >> call.expression(expr)')

--- a/test/template.usage.test.ts
+++ b/test/template.usage.test.ts
@@ -11,7 +11,7 @@ const LANGUAGE = 'postfix'
 const VAR_TEMPLATES = ['var', 'let', 'const']
 const FOR_TEMPLATES = ['for', 'forof', 'foreach']
 const CONSOLE_TEMPLATES = ['log', 'warn', 'error']
-const EQUALITY_TEMPLATES = ['null', 'notnull', 'undefined', 'notundefined']
+const EQUALITY_TEMPLATES = ['null', 'notnull', 'undefined', 'notundefined', 'new']
 const IF_TEMPLATES = ['if', 'else', 'null', 'notnull', 'undefined', 'notundefined']
 const CAST_TEMPLATES = ['cast', 'castas']
 const TYPE_TEMPLATES = ['promisify']
@@ -79,10 +79,10 @@ describe('Template usage', () => {
   testTemplateUsage('inside return - arrow function', 'return items.map(x => { result{cursor} })', ALL_TEMPLATES)
   testTemplateUsage('inside return - function', 'return items.map(function(x) { result{cursor} })', ALL_TEMPLATES)
 
-  testTemplateUsage('inside variable declaration', 'var test = expr{cursor}', [...CAST_TEMPLATES, ...EQUALITY_TEMPLATES, 'not', 'new', 'await'])
+  testTemplateUsage('inside variable declaration', 'var test = expr{cursor}', [...CAST_TEMPLATES, ...EQUALITY_TEMPLATES, 'not', 'await'])
   testTemplateUsage('inside assignment statement', 'test = expr{cursor}', [...CAST_TEMPLATES, ...EQUALITY_TEMPLATES, 'not'])
   testTemplateUsage('inside assignment statement - short-circuit', 'test *= expr{cursor}', [...CAST_TEMPLATES, ...EQUALITY_TEMPLATES, 'not'])
-  testTemplateUsage('inside return', 'return expr{cursor}', [...CAST_TEMPLATES, ...EQUALITY_TEMPLATES, 'not', 'new', 'await'])
+  testTemplateUsage('inside return', 'return expr{cursor}', [...CAST_TEMPLATES, ...EQUALITY_TEMPLATES, 'not', 'await'])
   testTemplateUsage('inside single line comment', '// expr', [])
   testTemplateUsage('inside multi line comment', '/* expr{cursor} */', [])
 


### PR DESCRIPTION
fixes https://github.com/ipatalas/vscode-postfix-ts/issues/109
fixes https://github.com/ipatalas/vscode-postfix-ts/issues/108#issuecomment-1429719522

partially fixes https://github.com/ipatalas/vscode-postfix-ts/issues/108 (at least for all of my cases)
